### PR TITLE
Add test include subdirs qualified nested menhir

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ Unreleased
 ----------
 
 - When a rule's action is interrupted, delete any leftover directory targets.
-  This is consistent with how we treat file targets. (@rgrinberg, 7564)
+  This is consistent with how we treat file targets. (#7564, @rgrinberg)
 
 - Fix plugin loading with findlib. The functionality was broken in 3.7.0.
   (#7556, @anmonteiro)

--- a/test/blackbox-tests/test-cases/include-qualified/menhir-nested.t/bar/baz.mly
+++ b/test/blackbox-tests/test-cases/include-qualified/menhir-nested.t/bar/baz.mly
@@ -1,0 +1,7 @@
+%token EOF
+
+%start<unit> unit
+%%
+
+unit:
+| EOF { () }

--- a/test/blackbox-tests/test-cases/include-qualified/menhir-nested.t/bar/dune
+++ b/test/blackbox-tests/test-cases/include-qualified/menhir-nested.t/bar/dune
@@ -1,0 +1,2 @@
+(menhir
+ (modules baz))

--- a/test/blackbox-tests/test-cases/include-qualified/menhir-nested.t/dune
+++ b/test/blackbox-tests/test-cases/include-qualified/menhir-nested.t/dune
@@ -1,0 +1,4 @@
+(include_subdirs qualified)
+
+(executable
+ (name foo))

--- a/test/blackbox-tests/test-cases/include-qualified/menhir-nested.t/dune-project
+++ b/test/blackbox-tests/test-cases/include-qualified/menhir-nested.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 3.7)
+(using menhir 2.1)
+(name foo)

--- a/test/blackbox-tests/test-cases/include-qualified/menhir-nested.t/foo.ml
+++ b/test/blackbox-tests/test-cases/include-qualified/menhir-nested.t/foo.ml
@@ -1,0 +1,3 @@
+let () =
+  Bar.Baz.unit (fun _ -> Bar.Baz.EOF) (Lexing.from_string "");
+  Format.printf "foo@."

--- a/test/blackbox-tests/test-cases/include-qualified/menhir-nested.t/run.t
+++ b/test/blackbox-tests/test-cases/include-qualified/menhir-nested.t/run.t
@@ -1,0 +1,5 @@
+The use of (include_subdirs qualified) should be compatible with the use of
+Menhir in other places than the root of the file hierarchy.
+
+  $ dune exec ./foo.exe
+  foo

--- a/test/blackbox-tests/test-cases/include-subdirs/menhir-nested.t/bar/baz.mly
+++ b/test/blackbox-tests/test-cases/include-subdirs/menhir-nested.t/bar/baz.mly
@@ -1,0 +1,7 @@
+%token EOF
+
+%start<unit> unit
+%%
+
+unit:
+| EOF { () }

--- a/test/blackbox-tests/test-cases/include-subdirs/menhir-nested.t/bar/dune
+++ b/test/blackbox-tests/test-cases/include-subdirs/menhir-nested.t/bar/dune
@@ -1,0 +1,2 @@
+(menhir
+ (modules baz))

--- a/test/blackbox-tests/test-cases/include-subdirs/menhir-nested.t/dune
+++ b/test/blackbox-tests/test-cases/include-subdirs/menhir-nested.t/dune
@@ -1,0 +1,4 @@
+(include_subdirs unqualified)
+
+(executable
+ (name foo))

--- a/test/blackbox-tests/test-cases/include-subdirs/menhir-nested.t/dune-project
+++ b/test/blackbox-tests/test-cases/include-subdirs/menhir-nested.t/dune-project
@@ -1,0 +1,3 @@
+(lang dune 3.7)
+(using menhir 2.1)
+(name foo)

--- a/test/blackbox-tests/test-cases/include-subdirs/menhir-nested.t/foo.ml
+++ b/test/blackbox-tests/test-cases/include-subdirs/menhir-nested.t/foo.ml
@@ -1,0 +1,3 @@
+let () =
+  Baz.unit (fun _ -> Baz.EOF) (Lexing.from_string "");
+  Format.printf "foo@."

--- a/test/blackbox-tests/test-cases/include-subdirs/menhir-nested.t/run.t
+++ b/test/blackbox-tests/test-cases/include-subdirs/menhir-nested.t/run.t
@@ -1,0 +1,5 @@
+The use of (include_subdirs unqualified) should be compatible with the use of
+Menhir in other places than the root of the file hierarchy.
+
+  $ dune exec ./foo.exe
+  foo


### PR DESCRIPTION
On a side note, it is very tempting to reorganise the tests slightly with:

- `include-subdirs` -> `include-subdirs/unqualified`
- `include-qualified` -> `include-subdirs/qualified`

but I didn't dare just doing that. I also noted a few other tests related to `(include_subdirs)` that could be moved to these directories, or that could be cleaned up a little bit. I'd happily open a PR for that (or build on top of this one).